### PR TITLE
Update Profiling.lua

### DIFF
--- a/WeakAuras/Profiling.lua
+++ b/WeakAuras/Profiling.lua
@@ -316,14 +316,32 @@ local function PrintOneProfile(popup, name, map, total)
   if map.count ~= 0 then
     popup:AddText(name .. "  ERROR: count is not zero:" .. " " .. map.count)
   end
+
   local percent = ""
   if total then
     percent = ", " .. string.format("%.2f", 100 * map.elapsed / total) .. "%"
   end
+
   local spikeInfo = ""
+  
   if map.spike then
-    spikeInfo = string.format("(%.2fms)", map.spike)
+    local color
+    local r, g, b, a
+
+    if map.spike < 2 then
+      r, g, b, a = WeakAuras.GetHSVTransition(map.spike / 2, 0, 1, 0, 1, 1, 1, 0, 1)
+    elseif map.spike >= 2 and map.spike < 3 then
+      r, g, b, a = WeakAuras.GetHSVTransition((map.spike - 2) , 1, 1, 0, 1, 1, 0.65, 0, 1)
+    else 
+      r, g, b, a = WeakAuras.GetHSVTransition(1, 1, 0, 0, 1, 1, 0, 0, 1)
+    end
+
+    color = string.format("|cff%02x%02x%02x", r * 255, g * 255, b * 255)
+    spikeInfo = string.format("%s(%.2fms)|r", color, map.spike)
+  else
+    spikeInfo = "" -- handle no map.spike
   end
+
   popup:AddText(string.format("%s |cff999999%.2fms%s %s|r", name, map.elapsed, percent, spikeInfo))
 end
 


### PR DESCRIPTION
# Description
From time to time, people ask on Discord to read their profiling, and a lot of white lines may be confusing. Usually, people answer by "remove everything with a spike greater than 2 or 3."

This change color the spike based on the value. 

0 to 2 [green gradient to yellow]
2-3 [orange to red]
3+ [red]

<!-- Coloring Spike for Profiling #4851-->


## Type of change

Please delete options that are not relevant.

- [X] New feature (non-breaking change which adds functionality)



## Checklist
<!-- These can be checked off after the pull request is submitted, in case you want discussion before they are completely ready -->

- [ ] My code follows the style guidelines of this project
- [ ] I have performed a self-review of my own code
- [ ] I have commented my code, particularly in hard-to-understand areas
- [ ] I have made corresponding changes to the documentation
- [ ] My changes generate no new warnings

<!-- Is there any additional work that needs to be done? If so, add it to the above list -->
